### PR TITLE
:sparkles: Email changing is allowed

### DIFF
--- a/src/api/controllers/member.ts
+++ b/src/api/controllers/member.ts
@@ -3,6 +3,7 @@ import { Controller } from '../../base/controller'
 import { resolveOptions } from '../common-query-params'
 import { MemberService } from '../../services/member'
 import {
+  EmailReservedError,
   NoOtherPresidentError,
   UsernameReservedError,
 } from '../../exception/member-errors'
@@ -130,6 +131,8 @@ export class MemberController implements Controller {
     } catch (err) {
       if (err instanceof UsernameReservedError)
         throw new ApiError(422, ApiErrorCode.USERNAME_RESERVED)
+      if (err instanceof EmailReservedError)
+        throw new ApiError(422, ApiErrorCode.EMAIL_RESERVED)
       throw err
     }
   }

--- a/src/api/routes/members.ts
+++ b/src/api/routes/members.ts
@@ -149,8 +149,8 @@ export class MemberRoutes extends RoutesProvider {
      *    tags:
      *     - Members
      *    description: |
-     *      A member can update his credentials (username and/or password) via this endpoint.
-     *      Either username or password has to be provided.
+     *      A member can update his credentials (email and/or username and/or password) via this endpoint.
+     *      At least one value (email, username or password) has to be provided.
      *
      *      **Authentication is required** before using this endpoint.
      *      Also, because it is a sensitive operation, the **current password** of the
@@ -176,7 +176,13 @@ export class MemberRoutes extends RoutesProvider {
      *      401:
      *        $ref: '#/components/responses/Unauthorized'
      *      422:
-     *        $ref: '#/components/responses/UsernameReserved'
+     *        description: |
+     *              - The given email is already in use inside the association. (errorCode: 'email-reserved').
+     *              - The given username is already in use inside the association. (errorCode: 'username-reserved').
+     *        content:
+     *           application/json:
+     *              schema:
+     *                $ref: '#/components/schemas/Error'
      *      429:
      *        $ref: '#/components/responses/SurpassedRateLimit'
      *      5XX:

--- a/src/dto/new-credentials.ts
+++ b/src/dto/new-credentials.ts
@@ -8,6 +8,10 @@ import { JoiPassword, JoiUsername } from '../utils/joi'
  *    NewCredentials:
  *      type: object
  *      properties:
+ *        email:
+ *          type: string
+ *          description: 'The new email to update to'
+ *          example: 'newemail@alibaba.com'
  *        username:
  *          type: string
  *          description: 'The username to update to'
@@ -22,13 +26,15 @@ import { JoiPassword, JoiUsername } from '../utils/joi'
  *         - password
  */
 export class NewCredentialsDto {
+  email!: string
   username!: string
   password!: string
 
   static validationSchema(): ObjectSchema<NewCredentialsDto> {
     return Joi.object({
+      email: Joi.string().email(),
       username: JoiUsername(),
       password: JoiPassword(),
-    }).or('username', 'password')
+    }).or('email', 'username', 'password')
   }
 }

--- a/src/exception/member-errors.ts
+++ b/src/exception/member-errors.ts
@@ -1,4 +1,4 @@
-import { ValueReservedError } from "./value-reserved-error";
+import { ValueReservedError } from './value-reserved-error'
 
 /**
  * Thrown when a given operation is only allowed for presidents
@@ -21,7 +21,11 @@ export class PresidentDeletionError extends Error {}
 export class NoOtherPresidentError extends Error {}
 
 /**
- * Thrown when the client wants a password that'a already reserved
+ * Thrown when the client wants a password that's already reserved
  */
 export class UsernameReservedError extends ValueReservedError {}
 
+/**
+ * Thrown when the client wants an email that's already reserved
+ */
+export class EmailReservedError extends ValueReservedError {}

--- a/src/repositories/member.ts
+++ b/src/repositories/member.ts
@@ -227,7 +227,7 @@ export class MemberRepository implements Repository {
     return await MemberModel.findByIdAndUpdate(
       id,
       {
-        $set: _.pick(newCredentials, ['username', 'password']),
+        $set: _.pick(newCredentials, ['email', 'username', 'password']),
       },
       { new: true },
     )


### PR DESCRIPTION
Now `email` can be modified through the `PATCH /api/members/me/credentials` endpoint.